### PR TITLE
Fix reference to wrong background feature

### DIFF
--- a/core/players-handbook/backgrounds/background-outlander.xml
+++ b/core/players-handbook/backgrounds/background-outlander.xml
@@ -42,7 +42,7 @@
     <rules>
       <grant type="Proficiency" name="ID_PROFICIENCY_SKILL_ATHLETICS" />
       <grant type="Proficiency" name="ID_PROFICIENCY_SKILL_SURVIVAL" />
-      <grant type="Background Feature" name="ID_BACKGROUND_FEATURE_SHELTER_OF_THE_FAITHFUL" />
+      <grant type="Background Feature" name="ID_BACKGROUND_FEATURE_WANDERER" />
       <select type="Proficiency" name="Musical Instrument (Outlander)" supports="Musical Instrument" />
       <select type="Language" name="Language (Outlander)" />
       <select name="Origin" type="List">


### PR DESCRIPTION
The Outlander background is referencing a background feature from the acolyte instead of the wanderer feature.